### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,5 +1,9 @@
 name: Security Scans
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/wiphoo/Website_Resources/security/code-scanning/1](https://github.com/wiphoo/Website_Resources/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it primarily reads repository contents and uploads SARIF files to the GitHub Security tab. Therefore, the `contents: read` and `security-events: write` permissions are sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions beyond these.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
